### PR TITLE
Callback and error handling callbacks to start, threaded close "works"

### DIFF
--- a/hisock/client.py
+++ b/hisock/client.py
@@ -118,6 +118,7 @@ class HiSockClient(_HiSockBase):
     :ivar int connect_time: An integer sotring the Unix timestamp of when the
         client connected to the server.
     """
+    
     def __init__(
         self,
         addr: tuple[str, int],

--- a/hisock/client.py
+++ b/hisock/client.py
@@ -542,7 +542,7 @@ class HiSockClient(_HiSockBase):
                     "client_disconnect",
                     _type_cast(
                         type_cast=dict,                      
-                        content_to_type_cast=_removeprefix(data, "$CLTDISCONN$"),
+                        content_to_type_cast=_removeprefix(data, b"$CLTDISCONN$"),
                         func_name="<client disconnect in update>",
                     ),
                 )

--- a/hisock/client.py
+++ b/hisock/client.py
@@ -118,7 +118,6 @@ class HiSockClient(_HiSockBase):
     :ivar int connect_time: An integer sotring the Unix timestamp of when the
         client connected to the server.
     """
-
     def __init__(
         self,
         addr: tuple[str, int],

--- a/hisock/server.py
+++ b/hisock/server.py
@@ -1103,8 +1103,8 @@ class HiSockServer(_HiSockBase):
         self.closed = True
         self._keepalive_event.set()
         self.disconnect_all_clients()
-        self.socket.close()
         self.socket.shutdown(socket.SHUT_RDWR)
+        self.socket.close()
 
     # Main loop
 

--- a/hisock/utils.py
+++ b/hisock/utils.py
@@ -183,21 +183,20 @@ def receive_message(
     :param header_len: The length of the header, so that
         it can successfully retrieve data without loss/gain of data
     :type header_len: int
+    :param timeout: The timeout for the socket. If None, there won't
+        be a timeout.
+    :type timeout: float, optional
     :return: A dictionary, with two key-value pairs;
         The first key-value pair refers to the header,
         while the second one refers to the actual data
     :rtype: Union[dict["header": bytes, "data": bytes], False
     """
 
-    try:
-        header_message = connection.recv(header_len)
-        if header_message:
-            message_len = int(header_message)
-            data = connection.recv(message_len)
-            return {"header": header_message, "data": data}
-    except ConnectionResetError:
-        # This is most likely where clients will disconnect
-        pass
+    header_message = connection.recv(header_len)
+    if header_message:
+        message_len = int(header_message)
+        data = connection.recv(message_len)
+        return {"header": header_message, "data": data}
     return False
 
 

--- a/hisock/utils.py
+++ b/hisock/utils.py
@@ -183,20 +183,21 @@ def receive_message(
     :param header_len: The length of the header, so that
         it can successfully retrieve data without loss/gain of data
     :type header_len: int
-    :param timeout: The timeout for the socket. If None, there won't
-        be a timeout.
-    :type timeout: float, optional
     :return: A dictionary, with two key-value pairs;
         The first key-value pair refers to the header,
         while the second one refers to the actual data
     :rtype: Union[dict["header": bytes, "data": bytes], False
     """
 
-    header_message = connection.recv(header_len)
-    if header_message:
-        message_len = int(header_message)
-        data = connection.recv(message_len)
-        return {"header": header_message, "data": data}
+    try:
+        header_message = connection.recv(header_len)
+        if header_message:
+            message_len = int(header_message)
+            data = connection.recv(message_len)
+            return {"header": header_message, "data": data}
+    except ConnectionResetError:
+        # This is most likely where clients will disconnect
+        pass
     return False
 
 


### PR DESCRIPTION
Adding callbacks for just a general callback that happens every time _update or _run finishes and for when an error occurs.

API breakage (because of course), however, this PR will also solve the threads... not actually being able to close (sorry 'bout that)

Please code review.